### PR TITLE
Restructuring the template data for a nicer table.

### DIFF
--- a/NodeMonitoring.html
+++ b/NodeMonitoring.html
@@ -4,8 +4,6 @@
 <%def name="content()">
 <img src=${module.dataset["filename_plot"].getArchiveUrl()} />
 
-<br/>
-
 <script type="text/javascript">
 $(function() {
 	function handle_ajax_response(data) {
@@ -57,24 +55,80 @@ $(function() {
 <br>
 <table class="TableData">
     %if module.dataset['SecondaryKey'] == '':
-        <tr><td>${module.dataset['PrimaryKey']}</td><td>${module.dataset['Attribute']}</td><td>Number of Jobs</td></tr>
+        <tr>
+        <td>${module.dataset['PrimaryKey']}</td>
+        %for value in attribute_values:
+        <td>${value}</td>
+        %endfor
+        </tr>
         %for entry in statistics:
             %if entry['PrimaryKeyURL'] == '':
-                <tr><td>${entry['PrimaryKey']}</td><td>${entry['AttributeValue']}</td><td>${entry['AttributeData']}</td></tr>
+                <tr>
+                <td>${entry['PrimaryKey']}</td>
+                %for value in attribute_values:
+                <td>
+                    %if value in entry:
+                        ${entry[value]}
+                    %else:
+                        -
+                    %endif
+                </td>
+                %endfor
+                </tr>
             %else:
-                <tr><td><a href="${entry['PrimaryKeyURL']}">${entry['PrimaryKey']}</a></td><td>${entry['AttributeValue']}</td><td>${entry['AttributeData']}</td></tr>
+                <tr>
+                <td><a href="${entry['PrimaryKeyURL']}">${entry['PrimaryKey']}</a></td>
+                %for value in attribute_values:
+                <td>
+                    %if value in entry:
+                        ${entry[value]}
+                    %else:
+                        -
+                    %endif
+                </td>
+                %endfor
+                </tr>
             %endif
         %endfor
     %else:
-        <tr><td>${module.dataset['PrimaryKey']}</td><td>${module.dataset['SecondaryKey']}</td><td>${module.dataset['Attribute']}</td><td>Number of Jobs</td></tr>
+        <tr>
+        <td>${module.dataset['PrimaryKey']}</td>
+        <td>${module.dataset['SecondaryKey']}</td>
+        %for value in attribute_values:
+        <td>${value}</td>
+        %endfor
+        </tr>
         %for entry in statistics:
             %if entry['PrimaryKeyURL'] == '':
-                <tr><td>${entry['PrimaryKey']}</td><td>${entry['SecondaryKey']}</td><td>${entry['AttributeValue']}</td><td>${entry['AttributeData']}</td></tr>
+                <tr>
+                <td>${entry['PrimaryKey']}</td>
+                <td>${entry['SecondaryKey']}</td>
+                %for value in attribute_values:
+                <td>
+                    %if value in entry:
+                        ${entry[value]}
+                    %else:
+                        -
+                    %endif
+                </td>
+                %endfor
+                </tr>
             %else:
-                <tr><td><a href="${entry['PrimaryKeyURL']}">${entry['PrimaryKey']}</a></td><td>${entry['SecondaryKey']}</td><td>${entry['AttributeValue']}</td><td>${entry['AttributeData']}</td></tr>
+                <tr>
+                <td><a href="${entry['PrimaryKeyURL']}">${entry['PrimaryKey']}</a></td>
+                <td>${entry['SecondaryKey']}</td>
+                %for value in attribute_values:
+                <td>
+                    %if value in entry:
+                        ${entry[value]}
+                    %else:
+                        -
+                    %endif
+                </td>
+                %endfor
+                </tr>
             %endif
         %endfor
     %endif
 </table>
 </%def>
-

--- a/NodeMonitoring.html
+++ b/NodeMonitoring.html
@@ -4,6 +4,8 @@
 <%def name="content()">
 <img src=${module.dataset["filename_plot"].getArchiveUrl()} />
 
+<br/>
+
 <script type="text/javascript">
 $(function() {
 	function handle_ajax_response(data) {

--- a/NodeMonitoring.py
+++ b/NodeMonitoring.py
@@ -464,5 +464,29 @@ class NodeMonitoring(hf.module.ModuleBase):
         details_list = self.subtables['statistics'].select().where(
                 self.subtables['statistics'].c.parent_id==self.dataset['id']
                 ).execute().fetchall()
-        data['statistics'] = map(dict, details_list)
+
+        current_entry = {}
+        restructured_details_list = []
+        attribute_values_list = []
+        current_primary_key = ""
+        current_primary_url = ""
+        statistics_dict = map(dict, details_list)
+
+        for entry in statistics_dict:
+            if current_primary_key != entry['PrimaryKey']:
+                if current_entry != {}: restructured_details_list.append(current_entry)
+                current_primary_key = entry['PrimaryKey']
+                current_entry = entry.copy()
+                av = current_entry.pop('AttributeValue').upper()
+                if attribute_values_list.count(av) == 0: attribute_values_list.append(av)
+                ad = current_entry.pop('AttributeData')
+                current_entry[av] = ad
+            else:
+                av = entry['AttributeValue'].upper()
+                if attribute_values_list.count(av) == 0: attribute_values_list.append(av)
+                ad = entry['AttributeData']
+                current_entry[av] = ad
+
+        data['statistics'] = restructured_details_list
+        data['attribute_values'] = attribute_values_list
         return data

--- a/NodeMonitoring.py
+++ b/NodeMonitoring.py
@@ -469,12 +469,11 @@ class NodeMonitoring(hf.module.ModuleBase):
         restructured_details_list = []
         attribute_values_list = []
         current_primary_key = ""
-        current_primary_url = ""
         statistics_dict = map(dict, details_list)
 
-        for entry in statistics_dict:
+        for i in range(len(statistics_dict)):
+            entry = statistics_dict[i]
             if current_primary_key != entry['PrimaryKey']:
-                if current_entry != {}: restructured_details_list.append(current_entry)
                 current_primary_key = entry['PrimaryKey']
                 current_entry = entry.copy()
                 av = current_entry.pop('AttributeValue').upper()
@@ -486,6 +485,13 @@ class NodeMonitoring(hf.module.ModuleBase):
                 if attribute_values_list.count(av) == 0: attribute_values_list.append(av)
                 ad = entry['AttributeData']
                 current_entry[av] = ad
+
+            # When a new or no primary key follows, the finished restructured entry is appended to the list
+            try:
+                if entry['PrimaryKey'] != statistics_dict[i+1]['PrimaryKey']:
+                    restructured_details_list.append(current_entry)
+            except:
+                restructured_details_list.append(current_entry)
 
         data['statistics'] = restructured_details_list
         data['attribute_values'] = attribute_values_list


### PR DESCRIPTION
To avoid several similar lines for one primary key on the html page, a new structure is introduced for the module NodeMonitoring. Now, for each primary key there is only one line containing all possible grid status names.

Please comment, whether the new format is acceptable.
