### PR TITLE
First draft of dashboard summary module

### DIFF
--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -3,17 +3,20 @@
 
 <%def name="content()">
 <script type="text/javascript">
-function ${module.instance_name}_plot_metric(metric_path){
-plot_window = window.open(metric_path, "_blank", "width=800,height=600");
-plot_window.focus();
-}
-
-function ${module.instance_name}_plot_test(){
-$('#${module.instance_name}_plot_form').submit();
+function ${module.instance_name}_plot_test(metric_name){
+$('#${module.instance_name}_data').append('<input type="hidden" name="filter" value="'+metric_name+'" />');
+$('#${module.instance_name}_data').submit();
 }
 </script>
 
-<div id='${module.instance_name}_latest_data'>
+<form id="${module.instance_name}_data" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
+<input name="module_instance_name" type="hidden" value="${module.instance_name}" />
+<input name="tier_name" type="hidden" value="${tier_name}" />
+<input name="subtable_name" type="hidden" value="formatted_history_data" />
+<input name="x_name" type="hidden" value="time" />
+<input name="y_name" type="hidden" value="status" />
+
+<input name="quantity_column_name" type="hidden" value="metric_name" />
 	<h3>Note: Currently used view option for dashboard metrics: "${view_option}"</h3>
 	<table class='TableData'>
 	<tr>
@@ -26,7 +29,7 @@ $('#${module.instance_name}_plot_form').submit();
 	<tr class='TableHeader'>
 		<td>Metric name</td>
 		<td colspan=2>UTC time of latest status</td>
-		<td colspan=2>Plot last 24 hours</td>
+		<td colspan=2>Plot status history</td>
 	</tr>
 	<%!
 	import time
@@ -48,23 +51,9 @@ $('#${module.instance_name}_plot_form').submit();
 		%endif
 		<td>${entry['metric_name']}</td>
 		<td colspan=2>${time.asctime(time.gmtime(entry['latest_time']))}</td>
-   	<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_metric('${plot_name}')"value="Plot Metric" name="Plot Metric" /></center></td>
+		<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test(#${entry['metric_name']})" value="Plot Metric" name="Plot Metric" /></center></td>
 		</tr>
 	%endfor
 	</table>
-</div>
-
-<form id="${module.instance_name}_plot_form" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
-<input name="module_instance_name" type="hidden" value="${module.instance_name}" />
-<input name="subtable_name" type="hidden" value="formatted_history_data" />
-<input name="x_name" type="hidden" value="time" />
-<input name="y_name" type="hidden" value="status" />
-<input name="quantity_column_name" type="hidden" value="metric_name" />
-<input name="chosen_quantity_name" type="hidden" value="AAA Federations">
-<table class='TableData'>
-<tr>
-<td colplan=2><center>${module.instance_name}</td> 
-<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test()"value="Plot Metric" name="Plot Metric" /></center></td></tr>
-</table>
 </form>
 </%def>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -1,0 +1,44 @@
+## -*- coding: utf-8 -*-
+<%inherit file="/module_base.html" />
+
+<%def name="content()">
+
+<div id='${module.instance_name}_latest_data'>
+	<h3>Note: Currently used view option for dashboard metrics: "${view_option}"</h3>
+	<table class='TableData'>
+	<tr>
+	<td>Status color coding used here:</td>
+	<td class='ok'>OK</td>
+	<td class='warning'>Warning</td>
+	<td class='critical'>Error</td>
+	<td class='undefined'>Other</td>
+	</tr>
+	<tr class='TableHeader'>
+		<td>Metric name</td>
+		<td colspan=2>UTC time of latest status</td>
+		<td colspan=2>Plot last 24 hours</td>
+	</tr>
+	<%!
+		import time
+	%>
+	%for entry in latest_data:
+		%if entry['latest_status'] == 3:
+			<tr class='critical'>
+		%elif entry['latest_status'] == 4:
+			<tr class='warning'>
+		%elif entry['latest_status'] == 5:
+			<tr class='ok'>
+		%elif entry['latest_status'] == -1:
+			<% continue %>
+		%else:
+			<tr class='undefined'>
+		%endif
+		<td>${entry['metric_name']}</td>
+		<td colspan=2>${time.asctime(time.gmtime(entry['latest_time']))}</td>
+		<td colspan=2>Plot Button</td>
+		</tr>
+	%endfor
+	</table>
+</div>
+
+</%def>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -56,7 +56,7 @@ $('#${module.instance_name}_plot_form').submit();
 
 <form id="${module.instance_name}_plot_form" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
 <input name="module_instance_name" type="hidden" value="${module.instance_name}" />
-<input name="subtable_name" type="hidden" value="allday_data" />
+<input name="subtable_name" type="hidden" value="formatted_history_data" />
 <input name="x_name" type="hidden" value="time" />
 <input name="y_name" type="hidden" value="status" />
 <input name="quantity_column_name" type="hidden" value="metric_name" />

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -17,8 +17,9 @@ $('#${module.instance_name}_data').submit();
 <input name="x_name" type="hidden" value="time" />
 <input name="y_name" type="hidden" value="status" />
 <input name="quantity_column_name" type="hidden" value="metric_name" />
+<input name="run_time" type="hidden" value="${run['time']}" />
 
-	<h3>Note: Currently used view option for dashboard metrics: "${view_option}"</h3>
+	<h3>Note: Currently used view option for dashboard metrics: <a href="${link_url}">"${view_option}"</a></h3>
 	<table class='TableData'>
 	<tr>
 	<td>Status color coding used here:</td>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -7,6 +7,10 @@ function ${module.instance_name}_plot_metric(metric_path){
 plot_window = window.open(metric_path, "_blank", "width=800,height=600");
 plot_window.focus();
 }
+
+function ${module.instance_name}_plot_test(){
+$('#${module.instance_name}_plot_form').submit();
+}
 </script>
 
 <div id='${module.instance_name}_latest_data'>
@@ -49,4 +53,8 @@ plot_window.focus();
 	%endfor
 	</table>
 </div>
+
+<form id="${module.instance_name}_plot_form" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
+<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test()"value="Plot Metric" name="Plot Metric" /></center></td>
+</form>
 </%def>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -55,6 +55,11 @@ $('#${module.instance_name}_plot_form').submit();
 </div>
 
 <form id="${module.instance_name}_plot_form" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
-<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test()"value="Plot Metric" name="Plot Metric" /></center></td>
+<input name="module_instance_name" type="hidden" value="${module.instance_name}" />
+<table class='TableData'>
+<tr>
+<td colplan=2><center>${module.instance_name}</td> 
+<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test()"value="Plot Metric" name="Plot Metric" /></center></td></tr>
+</table>
 </form>
 </%def>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -17,7 +17,7 @@ $('#${module.instance_name}_data').submit();
 <input name="x_name" type="hidden" value="time" />
 <input name="y_name" type="hidden" value="status" />
 <input name="quantity_column_name" type="hidden" value="metric_name" />
-<input name="run_time" type="hidden" value="${run['time']}" />
+<input name="run_id" type="hidden" value="${run['id']}" />
 
 	<h3>Note: Currently used view option for dashboard metrics: <a href="${link_url}">"${view_option}"</a></h3>
 	<table class='TableData'>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -2,6 +2,12 @@
 <%inherit file="/module_base.html" />
 
 <%def name="content()">
+<script type="text/javascript">
+function ${module.instance_name}_plot_metric(metric_path){
+plot_window = window.open(metric_path, "_blank", "width=800,height=600");
+plot_window.focus();
+}
+</script>
 
 <div id='${module.instance_name}_latest_data'>
 	<h3>Note: Currently used view option for dashboard metrics: "${view_option}"</h3>
@@ -19,9 +25,12 @@
 		<td colspan=2>Plot last 24 hours</td>
 	</tr>
 	<%!
-		import time
+	import time
 	%>
-	%for entry in latest_data:
+	%for entry,plot in zip(latest_data,plots):
+		<%
+			plot_name = module.dataset['filename_plot'].getArchiveUrl().replace("dashboard_summary",plot["filename_plot"])
+		%>
 		%if entry['latest_status'] == 3:
 			<tr class='critical'>
 		%elif entry['latest_status'] == 4:
@@ -35,10 +44,9 @@
 		%endif
 		<td>${entry['metric_name']}</td>
 		<td colspan=2>${time.asctime(time.gmtime(entry['latest_time']))}</td>
-		<td colspan=2>Plot Button</td>
+   	<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_metric('${plot_name}')"value="Plot Metric" name="Plot Metric" /></center></td>
 		</tr>
 	%endfor
 	</table>
 </div>
-
 </%def>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -56,6 +56,11 @@ $('#${module.instance_name}_plot_form').submit();
 
 <form id="${module.instance_name}_plot_form" method="get" action="${hf.plotgenerator.getCustomPlotUrl()}" target="_blank">
 <input name="module_instance_name" type="hidden" value="${module.instance_name}" />
+<input name="subtable_name" type="hidden" value="allday_data" />
+<input name="x_name" type="hidden" value="time" />
+<input name="y_name" type="hidden" value="status" />
+<input name="quantity_column_name" type="hidden" value="metric_name" />
+<input name="chosen_quantity_name" type="hidden" value="AAA Federations">
 <table class='TableData'>
 <tr>
 <td colplan=2><center>${module.instance_name}</td> 

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -4,7 +4,8 @@
 <%def name="content()">
 <script type="text/javascript">
 function ${module.instance_name}_plot_test(metric_name){
-$('#${module.instance_name}_data').append('<input type="hidden" name="filter" value="'+metric_name+'" />');
+$('[name=chosen_quantity_name]').remove();
+$('#${module.instance_name}_data').append('<input type="hidden" name="chosen_quantity_name" value="'+metric_name+'" />');
 $('#${module.instance_name}_data').submit();
 }
 </script>
@@ -51,7 +52,7 @@ $('#${module.instance_name}_data').submit();
 		%endif
 		<td>${entry['metric_name']}</td>
 		<td colspan=2>${time.asctime(time.gmtime(entry['latest_time']))}</td>
-		<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test(#${entry['metric_name']})" value="Plot Metric" name="Plot Metric" /></center></td>
+		<td colspan=2><center><input type="button" onclick = "${module.instance_name}_plot_test('${entry['metric_name']}')" value="Plot Metric" name="Plot Metric" /></center></td>
 		</tr>
 	%endfor
 	</table>

--- a/DashboardSummary.html
+++ b/DashboardSummary.html
@@ -16,8 +16,8 @@ $('#${module.instance_name}_data').submit();
 <input name="subtable_name" type="hidden" value="formatted_history_data" />
 <input name="x_name" type="hidden" value="time" />
 <input name="y_name" type="hidden" value="status" />
-
 <input name="quantity_column_name" type="hidden" value="metric_name" />
+
 	<h3>Note: Currently used view option for dashboard metrics: "${view_option}"</h3>
 	<table class='TableData'>
 	<tr>
@@ -35,10 +35,7 @@ $('#${module.instance_name}_data').submit();
 	<%!
 	import time
 	%>
-	%for entry,plot in zip(latest_data,plots):
-		<%
-			plot_name = module.dataset['filename_plot'].getArchiveUrl().replace("dashboard_summary",plot["filename_plot"])
-		%>
+	%for entry in latest_data:
 		%if entry['latest_status'] == 3:
 			<tr class='critical'>
 		%elif entry['latest_status'] == 4:

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -46,13 +46,15 @@ class DashboardSummary(hf.module.ModuleBase):
 	}
 	
 	def prepareAcquisition(self):
-		# Updating the url for a chosen view option. Possible options:
-		# default, maint, storage, test, transfers
-		# Further possiblities see on http://dashb-ssb.cern.ch/dashboard/request.py/sitehistory?site=T1_DE_KIT
+		# Updating the url for a chosen view option and tier site. Possible view options:
+		# default, maint, storage, test, transfers, Good links, Active Links, 
+		# Further possiblities see for example on http://dashb-ssb.cern.ch/dashboard/request.py/sitehistory?site=T1_DE_KIT
 		url = self.config['source_url']
 		old_view_option = url[url.find("view"):url.find("time")-1]
+		old_tier_name = url[url.find("site"):url.find("view")-1]
 		view_option_string = "view=" + self.config['view_option']
-		self.config['source_url'] = self.config['source_url'].replace(old_view_option,view_option_string)
+		tier_name_string = "site=" + self.config['tier_name']
+		self.config['source_url'] = self.config['source_url'].replace(old_view_option,view_option_string).replace(old_tier_name, tier_name_string)
 		try:
 			self.source = hf.downloadService.addDownload(self.config['source_url'])
 			self.source_url = self.source.getSourceUrl()

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -51,9 +51,9 @@ class DashboardSummary(hf.module.ModuleBase):
 		# Further possiblities see for example on http://dashb-ssb.cern.ch/dashboard/request.py/sitehistory?site=T1_DE_KIT
 		url = self.config['source_url']
 		old_view_option = url[url.find("view"):url.find("time")-1]
-		old_tier_name = url[url.find("site"):url.find("view")-1]
+		old_tier_name = url[url.find("?site"):url.find("view")-1]
 		view_option_string = "view=" + self.config['view_option']
-		tier_name_string = "site=" + self.config['tier_name']
+		tier_name_string = "?site=" + self.config['tier_name']
 		self.config['source_url'] = self.config['source_url'].replace(old_view_option,view_option_string).replace(old_tier_name, tier_name_string)
 		try:
 			self.source = hf.downloadService.addDownload(self.config['source_url'])

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -69,6 +69,7 @@ class DashboardSummary(hf.module.ModuleBase):
 		import matplotlib.pyplot as plt
 		data = {}
 		status_list = []
+		latest_status_list =[]
 		with open(self.source.getTmpPath(), 'r') as f:
 			data_object = json.loads(f.read())
 		
@@ -145,7 +146,6 @@ class DashboardSummary(hf.module.ModuleBase):
 			self.plots_list.append({"filename_plot": self.instance_name + 'plot' + str(index) + '.png'})
 			
 			# prepare lists to determine status
-			latest_status_list =[]
 			if info_latest['latest_status'] == 3: latest_status_list.append(0.0)
 			elif info_latest['latest_status'] == 4: latest_status_list.append(0.5)
 			elif info_latest['latest_status'] == 5: latest_status_list.append(1.0)

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -17,6 +17,7 @@
 import hf
 import json
 import time
+import numpy as np
 from sqlalchemy import *
 
 class DashboardSummary(hf.module.ModuleBase):
@@ -24,20 +25,24 @@ class DashboardSummary(hf.module.ModuleBase):
 	config_keys = {
 		'source_url' : ('Dashboard Summary URL', 'both||http://dashb-ssb.cern.ch/dashboard/request.py/getsiteplotdata?site=T1_DE_KIT&view=all&time=24&prettyprint=true'),
 		'view_option' : ('View option', 'test'),
+		'tier_name' : ('Name of the site', 'T1_DE_KIT')
 	}
 	
-	table_columns = [], []
+	table_columns = [Column("filename_plot", TEXT)],["filename_plot"]
 	subtable_columns = {
 		'latest_data' : ( [
 		Column('metric_name',TEXT),
 		Column('latest_status',INT),
-		Column('latest_time', INT)
+		Column('latest_time', INT),
 	], [] ),
 		'allday_data' : ( [
 		Column('metric_name',TEXT),
 		Column('status', INT),
 		Column('time',INT)
-	], [] )
+	], [] ),
+		'plots' : ( [
+		Column("filename_plot", TEXT)
+	], ["filename_plot"] )
 	}
 	
 	def prepareAcquisition(self):
@@ -56,14 +61,16 @@ class DashboardSummary(hf.module.ModuleBase):
 		
 		self.latest_data_db_value_list = []
 		self.allday_data_db_value_list = []
+		self.plots_list = []
 		
 	def extractData(self):
+		import matplotlib.pyplot as plt
 		data = {}
 		status_list = []
 		with open(self.source.getTmpPath(), 'r') as f:
 			data_object = json.loads(f.read())
 		
-		for metric in data_object['data']:
+		for index, metric in enumerate(data_object['data']):
 			info_latest = {'metric_name':metric[0],'latest_status':-1,'latest_time':-1}
 			info_allday_list = []
 			
@@ -79,24 +86,86 @@ class DashboardSummary(hf.module.ModuleBase):
 				
 				info_allday_list.insert(0,info)
 			
+			if len(info_allday_list) == 0: continue
 			self.latest_data_db_value_list.append(info_latest)
 			self.allday_data_db_value_list += info_allday_list
 			
+			### Creating plots
+			#prepare data
+			time_list = [info['time'] for info in info_allday_list]
+			status_list = []
+			for info in info_allday_list:
+				if info['status'] == 5: status_list.append(4)
+				elif info['status'] == 4: status_list.append(3)
+				elif info['status'] == 3: status_list.append(2)
+				elif info['status'] == 8: status_list.append(0)
+				else: status_list.append(1)
+
+			ylabel_list = ["other", "error", "warning", "ok"]
+			color_list = ["gray", "red", "orange", "green"]
+		
+			# create instance for a plot for the considered tier and metric
+			fig, ax1 = plt.subplots()
+			ax1.set_title("Metric {METRIC} for {TIER}".format(METRIC=info['metric_name'], TIER=self.config['tier_name']))
+			# edit y axis
+			ax1.set_ylim(0.5,4.5)
+			ax1.set_yticks(np.arange(1,5))
+			ax1.set_yticklabels(ylabel_list)
+			labels_list = ax1.get_yticklabels()
+			for i in range(len(labels_list)):
+				labels_list[i].set_color(color_list[i])
+				labels_list[i].set_weight('bold')
+		
+			# change plot borders
+			pos1_old = ax1.get_position()
+			ax1.set_position([pos1_old.x0,pos1_old.y0+0.3,pos1_old.width,pos1_old.height-0.3])
+
+			# edit x axis
+			step_size = (time_list[-1]-time_list[0])/10
+			time_tick_list = np.arange(time_list[0], time_list[-1], step_size)
+			time_ticklabel_list = [time.asctime(time.gmtime(t)) for t in time_tick_list]
+		
+			ax1.set_xlim([time_tick_list[0]-step_size*0.8,time_tick_list[-1]+step_size*0.8])
+			ax1.set_xticks(time_tick_list)
+			ax1.set_xticklabels(time_ticklabel_list, rotation='vertical', fontsize=9)
+			ax1.set_xlabel('UTC time')
+		
+			# add horizontal lines to highlight the status
+			for color, statusnumber in zip(color_list, np.arange(1,5)):
+				ax1.axhline(y=statusnumber, color=color, linewidth=8)
+		
+			# create graph for data
+			ax1.plot(time_list, status_list, color='white', marker='o', linestyle='None')
+		
+			# save the plot
+			filepath = hf.downloadService.getArchivePath(self.run, self.instance_name + 'plot' + str(index) + '.png')
+			fig.savefig(filepath, dpi=100)
+			self.plots_list.append({"filename_plot": self.instance_name + 'plot' + str(index) + '.png'})
+			
+			# prepare lists to determine status
 			if info_latest['latest_status'] == 3: status_list.append(0.0)
 			elif info_latest['latest_status'] == 4: status_list.append(0.5)
 			elif info_latest['latest_status'] == 5: status_list.append(1.0)
 		
+		# Save determined status
 		data['status'] = min(status_list)
+		
+		# Save plot directory
+		data['filename_plot'] = hf.downloadService.getArchivePath(self.run, self.instance_name)
+		
 		return data
 	
 	def fillSubtables(self, module_entry_id):
 		self.subtables['latest_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.latest_data_db_value_list])
 		self.subtables['allday_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.allday_data_db_value_list])
+		self.subtables['plots'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.plots_list])
 	def getTemplateData(self):
 		data = hf.module.ModuleBase.getTemplateData(self)
 		latest_data_list = self.subtables['latest_data'].select().where(self.subtables['latest_data'].c.parent_id==self.dataset['id']).execute().fetchall()
 		allday_data_list = self.subtables['allday_data'].select().where(self.subtables['allday_data'].c.parent_id==self.dataset['id']).execute().fetchall()
+		plots_list = self.subtables['plots'].select().where(self.subtables['plots'].c.parent_id==self.dataset['id']).execute().fetchall()
 		data['latest_data'] = map(dict, latest_data_list)
 		data['allday_data'] = map(dict, allday_data_list)
+		data['plots'] = map(dict, plots_list)
 		data['view_option'] = self.config['view_option']
 		return data

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -28,7 +28,7 @@ class DashboardSummary(hf.module.ModuleBase):
 		'tier_name' : ('Name of the site', 'T1_DE_KIT')
 	}
 	
-	table_columns = [Column("filename_plot", TEXT),["filename_plot"]
+	table_columns = [Column("filename_plot", TEXT)],["filename_plot"]
 	subtable_columns = {
 		'latest_data' : ( [
 		Column('metric_name',TEXT),

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -132,4 +132,5 @@ class DashboardSummary(hf.module.ModuleBase):
 		data['formatted_history_data'] = map(dict, formatted_history_data_list)
 		data['view_option'] = self.config['view_option']
 		data['tier_name'] = self.config['tier_name']
+		data['link_url'] =  'http://dashb-ssb.cern.ch/dashboard/request.py/sitehistory?site={SITE}#currentView={VIEW}&time=24&start_date=&end_date=&values=false&spline=false&white=false'.format(SITE=self.config['tier_name'], VIEW=self.config['view_option'])
 		return data

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -94,7 +94,7 @@ class DashboardSummary(hf.module.ModuleBase):
 			
 			### Creating plots
 			#prepare data
-			time_list = [info['time'] for info in info_allday_list]
+			time_list = [information['time'] for information in info_allday_list]
 			status_list = []
 			for info in info_allday_list:
 				if info['status'] == 5: status_list.append(4)
@@ -145,12 +145,13 @@ class DashboardSummary(hf.module.ModuleBase):
 			self.plots_list.append({"filename_plot": self.instance_name + 'plot' + str(index) + '.png'})
 			
 			# prepare lists to determine status
-			if info_latest['latest_status'] == 3: status_list.append(0.0)
-			elif info_latest['latest_status'] == 4: status_list.append(0.5)
-			elif info_latest['latest_status'] == 5: status_list.append(1.0)
+			latest_status_list =[]
+			if info_latest['latest_status'] == 3: latest_status_list.append(0.0)
+			elif info_latest['latest_status'] == 4: latest_status_list.append(0.5)
+			elif info_latest['latest_status'] == 5: latest_status_list.append(1.0)
 		
 		# Save determined status
-		data['status'] = min(status_list)
+		data['status'] = min(latest_status_list)
 		
 		# Save plot directory
 		data['filename_plot'] = hf.downloadService.getArchivePath(self.run, self.instance_name)

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -28,7 +28,7 @@ class DashboardSummary(hf.module.ModuleBase):
 		'tier_name' : ('Name of the site', 'T1_DE_KIT')
 	}
 	
-	table_columns = [Column("filename_plot", TEXT)],["filename_plot"]
+	table_columns = [Column("filename_plot", TEXT),["filename_plot"]
 	subtable_columns = {
 		'latest_data' : ( [
 		Column('metric_name',TEXT),
@@ -191,4 +191,5 @@ class DashboardSummary(hf.module.ModuleBase):
 		data['formatted_history_data'] = map(dict, formatted_history_data_list)
 		data['plots'] = map(dict, plots_list)
 		data['view_option'] = self.config['view_option']
+		data['tier_name'] = self.config['tier_name']
 		return data

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012 Institut für Experimentelle Kernphysik - Karlsruher Institut für Technologie
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import hf
+import json
+import time
+from sqlalchemy import *
+
+class DashboardSummary(hf.module.ModuleBase):
+	
+	config_keys = {
+		'source_url' : ('Dashboard Summary URL', 'both||http://dashb-ssb.cern.ch/dashboard/request.py/getsiteplotdata?site=T1_DE_KIT&view=all&time=24&prettyprint=true'),
+		'view_option' : ('View option', 'test'),
+	}
+	
+	table_columns = [], []
+	subtable_columns = {
+		'latest_data' : ( [
+		Column('metric_name',TEXT),
+		Column('latest_status',INT),
+		Column('latest_time', INT)
+	], [] ),
+		'allday_data' : ( [
+		Column('metric_name',TEXT),
+		Column('status', INT),
+		Column('time',INT)
+	], [] )
+	}
+	
+	def prepareAcquisition(self):
+		# Updating the url for a chosen view option. Possible options:
+		# default, maint, storage, test, transfers
+		# Further possiblities see on http://dashb-ssb.cern.ch/dashboard/request.py/sitehistory?site=T1_DE_KIT
+		url = self.config['source_url']
+		old_view_option = url[url.find("view"):url.find("time")-1]
+		view_option_string = "view=" + self.config['view_option']
+		self.config['source_url'] = self.config['source_url'].replace(old_view_option,view_option_string)
+		try:
+			self.source = hf.downloadService.addDownload(self.config['source_url'])
+			self.source_url = self.source.getSourceUrl()
+		except:
+			raise hf.exceptions.ConfigError('Not possible to set the source')
+		
+		self.latest_data_db_value_list = []
+		self.allday_data_db_value_list = []
+		
+	def extractData(self):
+		data = {}
+		status_list = []
+		with open(self.source.getTmpPath(), 'r') as f:
+			data_object = json.loads(f.read())
+		
+		for metric in data_object['data']:
+			info_latest = {'metric_name':metric[0],'latest_status':-1,'latest_time':-1}
+			info_allday_list = []
+			
+			# going through entries in data for the metric. Format of datapoint:
+			# [time in seconds, status in integers (coding see source_url)]
+			for datapoint in reversed(metric[1]):
+				info = {'metric_name':metric[0],'status':-1,'time':-1}
+				info['time'],info['status'] = datapoint
+				
+				# determining latest status for metric. Status 8 means, that it is not filled for that time.
+				if info_latest['latest_time'] == -1 and datapoint[1] != 8:
+					info_latest['latest_time'],info_latest['latest_status'] = datapoint
+				
+				info_allday_list.insert(0,info)
+			
+			self.latest_data_db_value_list.append(info_latest)
+			self.allday_data_db_value_list += info_allday_list
+			
+			if info_latest['latest_status'] == 3: status_list.append(0.0)
+			elif info_latest['latest_status'] == 4: status_list.append(0.5)
+			elif info_latest['latest_status'] == 5: status_list.append(1.0)
+		
+		data['status'] = min(status_list)
+		return data
+	
+	def fillSubtables(self, module_entry_id):
+		self.subtables['latest_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.latest_data_db_value_list])
+		self.subtables['allday_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.allday_data_db_value_list])
+	def getTemplateData(self):
+		data = hf.module.ModuleBase.getTemplateData(self)
+		latest_data_list = self.subtables['latest_data'].select().where(self.subtables['latest_data'].c.parent_id==self.dataset['id']).execute().fetchall()
+		allday_data_list = self.subtables['allday_data'].select().where(self.subtables['allday_data'].c.parent_id==self.dataset['id']).execute().fetchall()
+		data['latest_data'] = map(dict, latest_data_list)
+		data['allday_data'] = map(dict, allday_data_list)
+		data['view_option'] = self.config['view_option']
+		return data

--- a/DashboardSummary.py
+++ b/DashboardSummary.py
@@ -28,14 +28,14 @@ class DashboardSummary(hf.module.ModuleBase):
 		'tier_name' : ('Name of the site', 'T1_DE_KIT')
 	}
 	
-	table_columns = [Column("filename_plot", TEXT)],["filename_plot"]
+	table_columns = [],[]
 	subtable_columns = {
 		'latest_data' : ( [
 		Column('metric_name',TEXT),
 		Column('latest_status',INT),
 		Column('latest_time', INT),
 	], [] ),
-		'allday_data' : ( [
+		'history_data' : ( [
 		Column('metric_name',TEXT),
 		Column('status', INT),
 		Column('time',INT)
@@ -44,10 +44,7 @@ class DashboardSummary(hf.module.ModuleBase):
 		Column('metric_name',TEXT),
 		Column('status', INT),
 		Column('time',INT)
-	], [] ),
-		'plots' : ( [
-		Column("filename_plot", TEXT)
-	], ["filename_plot"] )
+	], [] )
 	}
 	
 	def prepareAcquisition(self):
@@ -67,7 +64,7 @@ class DashboardSummary(hf.module.ModuleBase):
 			raise hf.exceptions.ConfigError('Not possible to set the source')
 		
 		self.latest_data_db_value_list = []
-		self.allday_data_db_value_list = []
+		self.history_data_db_value_list = []
 		self.formatted_data_db_value_list = []
 		self.plots_list = []
 		
@@ -107,60 +104,8 @@ class DashboardSummary(hf.module.ModuleBase):
 			
 			if len(info_allday_list) == 0: continue
 			self.latest_data_db_value_list.append(info_latest)
-			self.allday_data_db_value_list += info_allday_list
+			self.history_data_db_value_list += info_allday_list
 			self.formatted_data_db_value_list += info_formatted_history_list
-			
-			### Creating plots
-			#prepare data
-			time_list = [information['time'] for information in info_allday_list]
-			status_list = []
-			for info in info_allday_list:
-				if info['status'] == 5: status_list.append(4)
-				elif info['status'] == 4: status_list.append(3)
-				elif info['status'] == 3: status_list.append(2)
-				elif info['status'] == 8: status_list.append(0)
-				else: status_list.append(1)
-
-			ylabel_list = ["other", "error", "warning", "ok"]
-			color_list = ["gray", "red", "orange", "green"]
-		
-			# create instance for a plot for the considered tier and metric
-			fig, ax1 = plt.subplots()
-			ax1.set_title("Metric {METRIC} for {TIER}".format(METRIC=info['metric_name'], TIER=self.config['tier_name']))
-			# edit y axis
-			ax1.set_ylim(0.5,4.5)
-			ax1.set_yticks(np.arange(1,5))
-			ax1.set_yticklabels(ylabel_list)
-			labels_list = ax1.get_yticklabels()
-			for i in range(len(labels_list)):
-				labels_list[i].set_color(color_list[i])
-				labels_list[i].set_weight('bold')
-		
-			# change plot borders
-			pos1_old = ax1.get_position()
-			ax1.set_position([pos1_old.x0,pos1_old.y0+0.3,pos1_old.width,pos1_old.height-0.3])
-
-			# edit x axis
-			step_size = (time_list[-1]-time_list[0])/10
-			time_tick_list = np.arange(time_list[0], time_list[-1], step_size)
-			time_ticklabel_list = [time.asctime(time.gmtime(t)) for t in time_tick_list]
-		
-			ax1.set_xlim([time_tick_list[0]-step_size*0.8,time_tick_list[-1]+step_size*0.8])
-			ax1.set_xticks(time_tick_list)
-			ax1.set_xticklabels(time_ticklabel_list, rotation='vertical', fontsize=9)
-			ax1.set_xlabel('UTC time')
-		
-			# add horizontal lines to highlight the status
-			for color, statusnumber in zip(color_list, np.arange(1,5)):
-				ax1.axhline(y=statusnumber, color=color, linewidth=8)
-		
-			# create graph for data
-			ax1.plot(time_list, status_list, color='white', marker='o', linestyle='None')
-		
-			# save the plot
-			filepath = hf.downloadService.getArchivePath(self.run, self.instance_name + 'plot' + str(index) + '.png')
-			fig.savefig(filepath, dpi=100)
-			self.plots_list.append({"filename_plot": self.instance_name + 'plot' + str(index) + '.png'})
 			
 			# prepare lists to determine status
 			if info_latest['latest_status'] == 3: latest_status_list.append(0.0)
@@ -170,26 +115,21 @@ class DashboardSummary(hf.module.ModuleBase):
 		# Save determined status
 		data['status'] = min(latest_status_list)
 		
-		# Save plot directory
-		data['filename_plot'] = hf.downloadService.getArchivePath(self.run, self.instance_name)
-		
 		return data
 	
 	def fillSubtables(self, module_entry_id):
 		self.subtables['latest_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.latest_data_db_value_list])
-		self.subtables['allday_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.allday_data_db_value_list])
+		self.subtables['history_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.history_data_db_value_list])
 		self.subtables['formatted_history_data'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.formatted_data_db_value_list])
-		self.subtables['plots'].insert().execute([dict(parent_id=module_entry_id, **row) for row in self.plots_list])
 	def getTemplateData(self):
 		data = hf.module.ModuleBase.getTemplateData(self)
 		latest_data_list = self.subtables['latest_data'].select().where(self.subtables['latest_data'].c.parent_id==self.dataset['id']).execute().fetchall()
-		allday_data_list = self.subtables['allday_data'].select().where(self.subtables['allday_data'].c.parent_id==self.dataset['id']).execute().fetchall()
+		history_data_list = self.subtables['history_data'].select().where(self.subtables['history_data'].c.parent_id==self.dataset['id']).execute().fetchall()
 		formatted_history_data_list = self.subtables['formatted_history_data'].select().where(self.subtables['formatted_history_data'].c.parent_id==self.dataset['id']).execute().fetchall()
-		plots_list = self.subtables['plots'].select().where(self.subtables['plots'].c.parent_id==self.dataset['id']).execute().fetchall()
+		
 		data['latest_data'] = map(dict, latest_data_list)
-		data['allday_data'] = map(dict, allday_data_list)
+		data['history_data'] = map(dict, history_data_list)
 		data['formatted_history_data'] = map(dict, formatted_history_data_list)
-		data['plots'] = map(dict, plots_list)
 		data['view_option'] = self.config['view_option']
 		data['tier_name'] = self.config['tier_name']
 		return data


### PR DESCRIPTION
I've made my first draft of the dashboard summary module, which Joram initiated by the following ticket:

https://ekptrac.physik.uni-karlsruhe.de/trac/HappyFace/ticket/84

For now, no plots are made, but the actual data is stored as latest measured data and data in the last 24 hours. Various view options for dashboard metrics can be set, for now it's the option "all".

For me, it's not quite clear in which of the existing categories this summary module fits best, since this is a rated module, so it cannot be used in News or Expert modules.

An example is run on my test instance:

http://ekphappyface.physik.uni-karlsruhe.de/HappyFace/art_test/category/batch#dashboard_summary
